### PR TITLE
Fix builds for Linux by adding missing object files

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -17,7 +17,10 @@ LDFLAGS+=-lm -lncurses -lutil $(LDEPS)
 OBJS=commands.o compat.o e_commands.o \
 	  keybindings.o medialib.o meta_info.o \
 	  paint.o player.o playlist.o \
-	  str2argv.o uinterface.o vitunes.o
+	  str2argv.o uinterface.o vitunes.o \
+	  mplayer.o socket.o player_utils.o
+
+VPATH = players
 
 # main targets
 


### PR DESCRIPTION
Add mplayer.o, socket.o and player_utils.o to
the list of required object files and add VPATH.
