### PR TITLE
Fixed memory leak in str2argv

### DIFF
--- a/str2argv.c
+++ b/str2argv.c
@@ -36,7 +36,7 @@ argv_free(int *argc, char ***argv)
 {
    int i;
 
-   for (i = 0; i < *argc; i++)
+   for (i = 0; i <= *argc; i++)
       free((*argv)[i]);
 
    free(*argv);


### PR DESCRIPTION
`argv_finish_token()` allocates `argc+1` number of times, since arrays are 0-indexed. Since `argv_free()` only frees `argc` times, this creates a memory leak. Fixed by changing `<` to `<=` in the loop condition.
